### PR TITLE
Create avvio.sh

### DIFF
--- a/riconoscimento/avvio.sh
+++ b/riconoscimento/avvio.sh
@@ -1,0 +1,3 @@
+#! bin/sh
+sleep 15
+python3 /home/pi/riconoscimento/confronto.py


### PR DESCRIPTION
il file avvio.sh dovrebbe rimanere all'interno della cartella riconoscimento, altrimenti quando si esegue sudo rm -r face-ha il file viene rimosso.